### PR TITLE
Synchronize WebSocket SendAsync calls

### DIFF
--- a/TikTokLiveSharp/Client/Socket/TikTokWebSocket.cs
+++ b/TikTokLiveSharp/Client/Socket/TikTokWebSocket.cs
@@ -95,7 +95,7 @@ namespace TikTokLiveSharp.Client.Socket
             {
                 token.ThrowIfCancellationRequested();
                 if (clientWebSocket == null)
-                    return; // Invalid socket (Connection was closed?)
+                    return;
                 await clientWebSocket.SendAsync(arr, WebSocketMessageType.Binary, true, token);
             }
             finally

--- a/TikTokLiveSharp/Client/Socket/TikTokWebSocket.cs
+++ b/TikTokLiveSharp/Client/Socket/TikTokWebSocket.cs
@@ -86,14 +86,23 @@ namespace TikTokLiveSharp.Client.Socket
         /// </summary>
         /// <param name="arr">The bytes to write</param>
         /// <returns>Task to await</returns>
+        private SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+        
         public async Task WriteMessage(ArraySegment<byte> arr)
         {
-            token.ThrowIfCancellationRequested();
-            if (clientWebSocket == null)
-                return; // Invalid socket (Connection was closed?)
-            await clientWebSocket.SendAsync(arr, WebSocketMessageType.Binary, true, token);
+            await semaphore.WaitAsync();
+            try
+            {
+                token.ThrowIfCancellationRequested();
+                if (clientWebSocket == null)
+                    return; // Invalid socket (Connection was closed?)
+                await clientWebSocket.SendAsync(arr, WebSocketMessageType.Binary, true, token);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
         }
-
         /// <summary>
         /// Receives a message from websocket. Result is Response-Message from Socket
         /// </summary>


### PR DESCRIPTION
Introduces a semaphore to synchronize calls to `SendAsync` in the `WriteMessage` method. This ensures that we do not call `SendAsync` again until the previous operation has completed, which resolves the `System.InvalidOperationException` we were encountering.

The changes include:
- Added a `SemaphoreSlim` instance to allow only one operation at a time.
- Updated the `WriteMessage` method to use the semaphore, ensuring that only one `SendAsync` operation happens at a time.