### PR TITLE
Fix duplicate GiftMessage

### DIFF
--- a/TikTokLiveSharp/Client/TikTokLiveClient.cs
+++ b/TikTokLiveSharp/Client/TikTokLiveClient.cs
@@ -803,9 +803,12 @@ namespace TikTokLiveSharp.Client
                 activeGifts[giftId].FinishStreak();
                 activeGifts.Remove(giftId);
             }
-            if (ShouldLog(LogLevel.Verbose))
-                Debug.Log($"Handling GiftMessage");
-            RunEvent(OnGiftMessage, new GiftMessage(message));
+            else
+            {
+                if (ShouldLog(LogLevel.Verbose))
+                    Debug.Log($"Handling GiftMessage");
+                RunEvent(OnGiftMessage, new GiftMessage(message));
+            }
         }
         /// <summary>
         /// Handles a WebcastSocialMessage


### PR DESCRIPTION
Fix to prevent duplicate gift messages from being handled. The issue was that the HandleGiftMessage function was being called for every gift message, even if the gift streak had ended.