### PR TITLE
Update Constants.cs

### DIFF
--- a/TikTokLiveSharp/Client/Config/Constants.cs
+++ b/TikTokLiveSharp/Client/Config/Constants.cs
@@ -102,6 +102,6 @@ namespace TikTokLiveSharp.Client.Config
             
         });
 
-        public static readonly KeyValuePair<string, string> COMPRESSION_HEADER = new KeyValuePair<string, string>( "Accept-Encoding", "gzip, deflate, br" );
+        public static readonly KeyValuePair<string, string> COMPRESSION_HEADER = new KeyValuePair<string, string>( "Accept-Encoding", "gzip, deflate" );
     }
 }


### PR DESCRIPTION
remove br from "Accept-Encoding", "gzip, deflate, br"
TiktokLiveUnity traces this error: "Your IP or country might be blocked by TikTok." the error message was misleading.