### PR TITLE
Dotnet add RunAsync method

### DIFF
--- a/TikTokLiveSharp/Client/TikTokBaseClient.cs
+++ b/TikTokLiveSharp/Client/TikTokBaseClient.cs
@@ -340,6 +340,23 @@ namespace TikTokLiveSharp.Client
         }
 
         /// <summary>
+        /// Asynchronously Creates Threads for & Runs Connection with TikTokServers
+        /// </summary>
+        /// <param name="cancellationToken">Token used to Cancel Client</param>
+        /// <param name="onConnectException">Callback for Errors during Exception</param>
+        /// <param name="retryConnection">Whether to Retry connections that might be recoverable</param>
+        public async Task RunAsync(CancellationToken? cancellationToken = null, Action<Exception> onConnectException = null, bool retryConnection = false)
+        {
+            token = cancellationToken ?? new CancellationToken();
+            token.ThrowIfCancellationRequested();
+            if (ShouldLog(LogLevel.Information))
+                Debug.Log("Starting Threads");
+            await Start(token, onConnectException, retryConnection);
+            await runningTask;
+            await pollingTask;
+        }
+        
+        /// <summary>
         /// Starts Connection with TikTokServers
         /// </summary>
         /// <param name="cancellationToken">Token used to Cancel Client</param>

--- a/TikTokLiveSharp_TestApplication/Program.cs
+++ b/TikTokLiveSharp_TestApplication/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using TikTokLiveSharp.Client;
 using TikTokLiveSharp.Events;
 
@@ -7,8 +8,9 @@ namespace TikTokLiveSharpTestApplication
 {
     internal class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
+            
             Console.WriteLine("Enter a username:");            
             TikTokLiveClient client = new TikTokLiveClient(Console.ReadLine(), "");
             client.OnConnected += Client_OnConnected;
@@ -23,9 +25,18 @@ namespace TikTokLiveSharpTestApplication
             client.OnLike += Client_OnLike;
             client.OnGiftMessage += Client_OnGiftMessage;
             client.OnEmoteChat += Client_OnEmote;
-            client.Run(new System.Threading.CancellationToken());
+            
+            if (args.Length > 0 && args[0] == "--async")
+            {
+                await client.RunAsync(new System.Threading.CancellationToken());
+            }
+            
+            else
+            {
+                client.Run(new System.Threading.CancellationToken());
+            }
         }
-
+        
         private static void Client_OnConnected(TikTokLiveClient sender, bool e)
         {
             SetConsoleColor(ConsoleColor.White);


### PR DESCRIPTION
This adds a RunAsync method, which is an asynchronous overload of TikTokBaseClient.Run. It also adds an --async flag to the test application for testing.

Many method calls within Run were already asynchronous, so the new method just awaits them instead calling Task.Run.

This allows a parent application more control over the threads of the TikTokLiveClient. For example, you can now pause threads while the client waits for the OnConnected event to fire, instead of relying solely on the events themselves.