### PR TITLE
Fixes #103, empty json data for live info.

### DIFF
--- a/TikTokLiveSharp/Client/Config/Constants.cs
+++ b/TikTokLiveSharp/Client/Config/Constants.cs
@@ -23,7 +23,11 @@ namespace TikTokLiveSharp.Client.Config
         /// <summary>
         /// User-Agent for WebClients (Http/WebSocket)
         /// </summary>
-        public const string USER_AGENT = "5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.63 Safari/537.36";
+        public const string USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+        /// <summary>
+        /// Browser version for WebClients parameter (Http/WebSocket)
+        /// </summary>
+        public const string BROWSER_VERSION = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";/// <summary>
         /// <summary>
         /// Default TimeOut for Connections
         /// </summary>
@@ -71,7 +75,7 @@ namespace TikTokLiveSharp.Client.Config
             { "browser_name", "Mozilla" },
             { "browser_online", true },
             { "browser_platform", "Win32" },
-            { "browser_version", USER_AGENT },
+            { "browser_version", BROWSER_VERSION },
             { "cookie_enabled", true },
             { "cursor", "" },
             { "internal_ext", "" },
@@ -92,7 +96,6 @@ namespace TikTokLiveSharp.Client.Config
             { "referer", "https, //www.tiktok.com/" },
             { "root_referer", "https, //www.tiktok.com/" },
             { "msToken", "" },
-            { "version_code", 180800 },
             { "webcast_sdk_version", "1.3.0" },
             { "update_version_code", "1.3.0" }
         });

--- a/TikTokLiveSharp/TikTokLiveSharp.csproj
+++ b/TikTokLiveSharp/TikTokLiveSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>Frank van Hoof</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/frankvHoof93/TikTokLiveSharp</PackageProjectUrl>


### PR DESCRIPTION
Fixes #103 

Built and tested on my end against a live user and everything seems to connect and work now. 

TikTok changed something almost two days ago, the version_code is removed and will break getting the Live info endpoint and removing it doesn't seem to affect anything else.  We had to put in a similar fix to the node-js library.  

That wasn't enough to fix this library though.

It appears that this library was missing the first part of the USER_AGENT as well and that was also causing the issue.  Once I updated it with Mozilla in the front it started working.  I went ahead and made a new BROWSER_VERSION value for that parameter.  It still seemed to work with the modified user agent, but I made it equal to what our browsers are still sending tiktok.
